### PR TITLE
Fix migrations failing with defaultSafeIntegers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,11 @@ export default (database: Database, migrations: Query[]): number => {
   return database.executeTransaction(() => {
     let executedMigrationsCount: number;
     try {
-      executedMigrationsCount = database.get<{ seq: number }>(
-        sql`SELECT "seq" FROM "sqlite_sequence" WHERE "name" = ${"leafacMigrations"}`
-      )!.seq;
+      executedMigrationsCount = Number(
+        database.get<{ seq: number | bigint }>(
+          sql`SELECT "seq" FROM "sqlite_sequence" WHERE "name" = ${"leafacMigrations"}`
+        )!.seq
+      );
     } catch (error) {
       executedMigrationsCount = 0;
     }


### PR DESCRIPTION
database.defaultSafeIntegers() makes it so all int columns return
bigints rather than numbers.
After running the migrations more than once, it will fail with a
cryptic error, because the .toString() of bigint does not suffix 'n':
The AUTOINCREMENT sequence of the leafacMigrations table (4)
doesn’t match its number of rows (4)

Checking formatting...
All matched files use Prettier code style!
 PASS  src/index.test.ts
  ✓ No migrations (4 ms)
  ✓ One migration run twice (3 ms)
  ✓ Multiple migrations run twice (3 ms)
  ✓ Multiple migrations run twice, with defaultSafeIntegers (2 ms)
  ✓ One migration and then two (3 ms)
  ✓ Insert a migration into leafacMigrations by hand (1 ms)
  ✓ Delete a migration from leafacMigrations by hand (1 ms)
  ✓ Pass fewer migrations than already run (1 ms)
  ✓ Change a migration (3 ms)
  ✓ Invalid SQL (1 ms)
  ✓ Invalid SQL because of interpolation (1 ms)
  ✓ An error rolls back all migrations (2 ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   59 passed, 59 total
Time:        1.983 s, estimated 2 s
Ran all test suites.